### PR TITLE
Change link in deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {ponos,  "", {git, "git@github.com:klarna/ponos.git",    {ref, "5b202cc3dda2aca2c08de1dba152681f26a8f8dc"}}},
+    {ponos,  "", {git, "https://github.com/klarna/ponos.git",    {ref, "5b202cc3dda2aca2c08de1dba152681f26a8f8dc"}}},
     {folsom, "0.8.5"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"bear">>,{pkg,<<"bear">>,<<"0.8.5">>},1},
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.5">>},0},
  {<<"ponos">>,
-  {git,"git@github.com:klarna/ponos.git",
+  {git,"https://github.com/klarna/ponos.git",
        {ref,"5b202cc3dda2aca2c08de1dba152681f26a8f8dc"}},
   0}]}.
 [


### PR DESCRIPTION
With `git@github.com...` it couldn't download the dependency giving an error, `https://...` fixed that.

(I'm trying to make `aeload` work again)